### PR TITLE
SQS Extension - Add string and byte array converters

### DIFF
--- a/Amazon.SQS/src/Extensions.SQS/Bootstrapper/SqsExtensionProvider.cs
+++ b/Amazon.SQS/src/Extensions.SQS/Bootstrapper/SqsExtensionProvider.cs
@@ -1,6 +1,7 @@
 ﻿using Amazon.SQS.Model;
 using Microsoft.Azure.WebJobs;
 using Azure.Functions.Extensions.SQS.Collector;
+using System.Text;  
 
 namespace Azure.Functions.Extensions.SQS
 {
@@ -32,8 +33,23 @@ namespace Azure.Functions.Extensions.SQS
             var queueCollectorRule = context.AddBindingRule<SqsQueueOutAttribute>();
             queueCollectorRule.BindToCollector(attr => new SqsQueueAsyncCollector(attr));
             queueCollectorRule.AddConverter<SqsQueueMessage, SendMessageRequest>(ConvertSqsQueueMessageToSendMessageRequest);
+            queueCollectorRule.AddConverter<string, SendMessageRequest>(ConvertStringToSendMessageRequest);
+            queueCollectorRule.AddConverter<byte[], SendMessageRequest>(ConvertByteArrayToSendMessageRequest);
         }
 
+        
+        private static SendMessageRequest ConvertByteArrayToSendMessageRequest(byte[] body) 
+        {
+            var utfString = Encoding.UTF8.GetString(body, 0, body.Length);
+            return ConvertStringToSendMessageRequest(utfString);
+        }
+        private static SendMessageRequest ConvertStringToSendMessageRequest(string body)
+        {
+	        return new SendMessageRequest
+	        {
+                MessageBody = body
+	        };
+        }
         private static SendMessageRequest ConvertSqsQueueMessageToSendMessageRequest(SqsQueueMessage sqsQueueMessage)
         {
 	        return new SendMessageRequest


### PR DESCRIPTION
Hi @laveeshb! I've added string and byte[] converters for the sqs output binding. This allows the binding to be consumed from a JS worker.