### PR TITLE
Concurrent processing

### DIFF
--- a/Amazon.SQS/src/Extensions.SQS/Trigger/SqsQueueTriggerListener.cs
+++ b/Amazon.SQS/src/Extensions.SQS/Trigger/SqsQueueTriggerListener.cs
@@ -77,11 +77,7 @@ namespace Azure.Functions.Extensions.SQS
 
             var result = await this.AmazonSQSClient.ReceiveMessageAsync(getMessageRequest);
             Console.WriteLine($"Invoked the queue trigger at '{DateTime.UtcNow} UTC'. Fetched messages count: '{result.Messages.Count}'.");
-
-            foreach (var message in result.Messages)
-            {
-                await ProcessMessage(message);
-            }
+            await Task.WhenAll(result.Messages.Select(ProcessMessage));
         }
 
         private async Task ProcessMessage(Message message) 


### PR DESCRIPTION
Hi! I've made a little tweak on the listener. 
Currently a client can specify `MaxNumberOfMessages` to get several messages from the queue, but then those messages are processed sequentally, slowing the overall process. 

I rewrote the part that calls the executor to use `await Task.WhenAll` instead of `foreach + await`. This way, the messages are processed concurrently.

Let me know if you have any thoughts!